### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,4 @@ gem 'nokogiri'
 gem 'sass'
 gem 'sprockets', '~> 4.0.beta' , { require: false }
 gem 'uglifier'
+gem 'rake'


### PR DESCRIPTION
`/tool/install.sh fails` fails for me without adding this:

```
Installing sassc 1.12.1 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/mit/tmp/site-angulardart/vendor/bundle/gems/sassc-1.12.1/ext
rake RUBYARCHDIR\=/Users/mit/tmp/site-angulardart/vendor/bundle/extensions/x86_64-darwin-18/2.4.0/sassc-1.12.1
RUBYLIBDIR\=/Users/mit/tmp/site-angulardart/vendor/bundle/extensions/x86_64-darwin-18/2.4.0/sassc-1.12.1
/Users/mit/.rvm/rubies/ruby-2.4.3/lib/ruby/site_ruby/2.4.0/rubygems.rb:283:in `find_spec_for_exe': can't find gem rake (>= 0.a) with
executable rake (Gem::GemNotFoundException)
	from /Users/mit/.rvm/rubies/ruby-2.4.3/lib/ruby/site_ruby/2.4.0/rubygems.rb:302:in `activate_bin_path'
	from /Users/mit/.rvm/gems/ruby-2.4.3/bin/rake:23:in `<main>'
	from /Users/mit/.rvm/gems/ruby-2.4.3/bin/ruby_executable_hooks:24:in `eval'
	from /Users/mit/.rvm/gems/ruby-2.4.3/bin/ruby_executable_hooks:24:in `<main>'

rake failed, exit code 1
```

I found the solution to this in: https://github.com/sass/sassc-ruby/issues/86