### PR TITLE
Make code tabs work again

### DIFF
--- a/src/guide/dependency-injection.md
+++ b/src/guide/dependency-injection.md
@@ -1,4 +1,5 @@
 ---
+layout: angular
 title: Dependency Injection
 description: Angular's dependency injection system creates and delivers dependent services "just-in-time".
 sideNavGroup: basic

--- a/src/guide/router/1.md
+++ b/src/guide/router/1.md
@@ -1,4 +1,5 @@
 ---
+layout: angular
 title: Routing Basics
 description: Getting started with the router
 sideNavGroup: advanced

--- a/src/guide/router/2.md
+++ b/src/guide/router/2.md
@@ -1,4 +1,5 @@
 ---
+layout: angular
 title: Default, Redirect and Wildcard Routes
 sideNavGroup: advanced
 prevpage:

--- a/src/guide/router/3.md
+++ b/src/guide/router/3.md
@@ -1,4 +1,5 @@
 ---
+layout: angular
 title: Imperative Navigation and Route Parameters
 sideNavGroup: advanced
 prevpage:

--- a/src/guide/router/4.md
+++ b/src/guide/router/4.md
@@ -1,4 +1,5 @@
 ---
+layout: angular
 title: Child & Relative Routes
 sideNavGroup: advanced
 prevpage:

--- a/src/guide/router/5.md
+++ b/src/guide/router/5.md
@@ -1,4 +1,5 @@
 ---
+layout: angular
 title: Router Lifecycle Hooks
 sideNavGroup: advanced
 prevpage:

--- a/src/guide/router/6.md
+++ b/src/guide/router/6.md
@@ -1,4 +1,5 @@
 ---
+layout: angular
 title: Asynchronous Routing
 sideNavGroup: advanced
 prevpage:

--- a/src/guide/router/appendices.md
+++ b/src/guide/router/appendices.md
@@ -1,4 +1,5 @@
 ---
+layout: angular
 title: Appendices
 sideNavGroup: advanced
 prevpage:

--- a/src/guide/router/index.md
+++ b/src/guide/router/index.md
@@ -1,4 +1,5 @@
 ---
+layout: angular
 title: Routing Overview
 description: Overview of core router features
 sideNavGroup: advanced


### PR DESCRIPTION
`<code-tabs>` weren't working in pages that lost/lacked "layout: angular" in the top YAML.

Fixes #32