### PR TITLE
Update AngularDart site references to Google Ads

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -36,7 +36,7 @@ description: AngularDart is a web app framework that focuses on productivity, pe
           sophisticated, mission-critical apps that
           bring in much of Google’s revenue.
           <a href="https://news.dartlang.org/2016/03/the-new-adwords-ui-uses-dart-we-asked.html"  class="no-automatic-external">Learn more</a>
-          about how Google AdWords was enabled by AngularDart.</p>
+          about how Google Ads was enabled by AngularDart.</p>
 
           <h2>Open source</h2>
           <p>AngularDart is an open source project built on the

--- a/src/reference/videos.md
+++ b/src/reference/videos.md
@@ -13,7 +13,7 @@ Learn more about AngularDart with the following videos.
 * [Create First Pokemon AngularDart App \| Data Binding \| Ep1](https://www.youtube.com/watch?v=yWIFBsTT2Ag){: .no-automatic-external}
 
 <img src="images/Google-AdWords-Next-Interface-800x342.png"
-  alt="Screenshot of AdWords Next"
-  title="The UI of AdWords Next">
+  alt="Screenshot of Google Ads"
+  title="The UI of Google Ads">
 
 


### PR DESCRIPTION
It was still using the old name, Google AdWords