### PR TITLE
Fix <code-tabs> on hierarchical dependency injection page.

### DIFF
--- a/src/guide/hierarchical-dependency-injection.md
+++ b/src/guide/hierarchical-dependency-injection.md
@@ -1,4 +1,5 @@
 ---
+layout: angular
 title: Hierarchical Dependency Injectors
 description: Angular's hierarchical dependency injection system supports nested injectors in parallel with the component tree.
 sideNavGroup: advanced


### PR DESCRIPTION
Added missed `layout: angular` to make <code-tabs> work on hierarchical dependency injection page (https://angulardart.dev/guide/hierarchical-dependency-injection)