### PR TITLE
Link checking: drop --fail-on-warnings for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ env:
     - TEST_OPT2="--filter=ng/doc/[t-z]"
     - TZ=US/Pacific # normalize build timestamp
   matrix:
-    - TASK="./tool/build.sh --check --check-links-external-on-cron --fail-on-warnings"
+    - TASK="./tool/build.sh --check --check-links-external-on-cron"
     # Why the following --skip regex? Because some of the most recent
     # (non-alpha) versions of angular_* packages depend on angular 6-alpha,
     # which we haven't updated to yet. Only check the `angular` package version


### PR DESCRIPTION
The `--fail-on-warnings` flag triggers false positives when external links are checked since connection failures are reported as warnings (and there are almost always connection failures). Drop the flag for now.