### PR TITLE
Upgrade to Dart 2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: trusty
 sudo: required
 language: dart
-dart: 2.6.1
+dart: 2.7.0
 
 cache:
   timeout: 1000


### PR DESCRIPTION
The last commit updated the pubspec.lock files, apparently no other updates, under D27, are necessary.