### PR TITLE
Use stream_transform extension methods

### DIFF
--- a/examples/ng/doc/server-communication/lib/src/wiki/wiki_smart_component.dart
+++ b/examples/ng/doc/server-communication/lib/src/wiki/wiki_smart_component.dart
@@ -24,10 +24,9 @@ class WikiSmartComponent {
 
   WikiSmartComponent(this._wikipediaService) {
     _onSearchTerm.stream
-        .transform(debounce(Duration(milliseconds: 300)))
+        .debounce(Duration(milliseconds: 300))
         .distinct()
-        .transform(
-            switchMap((term) => _wikipediaService.search(term).asStream()))
+        .switchMap((term) => _wikipediaService.search(term).asStream())
         .forEach((data) {
       items = data;
     });

--- a/examples/ng/doc/server-communication/pubspec.yaml
+++ b/examples/ng/doc/server-communication/pubspec.yaml
@@ -3,13 +3,13 @@ description: Server Communication
 version: 0.0.1
 
 environment:
-  sdk: '>=2.5.0 <3.0.0'
+  sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
   angular: ^5.3.0
   http: ^0.12.0
   jsonpadding: ^1.0.2
-  stream_transform: ^0.0.5
+  stream_transform: ^1.0.0
 
 dev_dependencies:
   build_runner: ^1.7.0

--- a/examples/ng/doc/toh-6/lib/src/hero_search_component.dart
+++ b/examples/ng/doc/toh-6/lib/src/hero_search_component.dart
@@ -36,11 +36,11 @@ class HeroSearchComponent implements OnInit {
   // #docregion search
   void ngOnInit() async {
     heroes = _searchTerms.stream
-        .transform(debounce(Duration(milliseconds: 300)))
+        .debounce(Duration(milliseconds: 300))
         .distinct()
-        .transform(switchMap((term) => term.isEmpty
+        .switchMap((term) => term.isEmpty
             ? Stream<List<Hero>>.fromIterable([<Hero>[]])
-            : _heroSearchService.search(term).asStream()))
+            : _heroSearchService.search(term).asStream())
         .handleError((e) {
       print(e); // for demo purposes only
     });

--- a/examples/ng/doc/toh-6/pubspec.yaml
+++ b/examples/ng/doc/toh-6/pubspec.yaml
@@ -3,14 +3,14 @@ description: Tour of Heroes
 version: 0.0.1
 
 environment:
-  sdk: '>=2.5.0 <3.0.0'
+  sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
   angular: ^5.3.1
   angular_forms: ^2.1.0
   angular_router: ^2.0.0-alpha
   http: ^0.12.0
-  stream_transform: ^0.0.19
+  stream_transform: ^1.0.0
 
 dev_dependencies:
   angular_test: ^2.3.0

--- a/examples/ng/doc/toh-6/pubspec.yaml
+++ b/examples/ng/doc/toh-6/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   angular_forms: ^2.1.0
   angular_router: ^2.0.0-alpha
   http: ^0.12.0
-  stream_transform: ^1.0.0
+  stream_transform: ">=0.0.20 <1.0.0"
 
 dev_dependencies:
   angular_test: ^2.3.0

--- a/src/tutorial/toh-pt6.md
+++ b/src/tutorial/toh-pt6.md
@@ -70,7 +70,7 @@ Update package dependencies by adding the Dart [http][] and
    angular_forms: ^2.1.0
    angular_router: ^2.0.0-alpha
 +  http: ^0.12.0
-+  stream_transform: ^0.0.19
++  stream_transform: ^1.0.0
 ```
 
 <?code-excerpt path-base="examples/ng/doc/toh-6"?>
@@ -726,11 +726,11 @@ Create the `HeroSearchComponent` class and metadata.
 
     void ngOnInit() async {
       heroes = _searchTerms.stream
-          .transform(debounce(Duration(milliseconds: 300)))
+          .debounce(Duration(milliseconds: 300))
           .distinct()
-          .transform(switchMap((term) => term.isEmpty
+          .switchMap((term) => term.isEmpty
               ? Stream<List<Hero>>.fromIterable([<Hero>[]])
-              : _heroSearchService.search(term).asStream()))
+              : _heroSearchService.search(term).asStream())
           .handleError((e) {
         print(e); // for demo purposes only
       });
@@ -772,11 +772,11 @@ You can turn the stream of search terms into a stream of `Hero` lists and assign
   // ···
   void ngOnInit() async {
     heroes = _searchTerms.stream
-        .transform(debounce(Duration(milliseconds: 300)))
+        .debounce(Duration(milliseconds: 300))
         .distinct()
-        .transform(switchMap((term) => term.isEmpty
+        .switchMap((term) => term.isEmpty
             ? Stream<List<Hero>>.fromIterable([<Hero>[]])
-            : _heroSearchService.search(term).asStream()))
+            : _heroSearchService.search(term).asStream())
         .handleError((e) {
       print(e); // for demo purposes only
     });
@@ -789,11 +789,11 @@ taxing server resources and burning through the cellular network data plan.
 Instead, you can chain `Stream` operators that reduce the request flow to the string `Stream`.
 You'll make fewer calls to the `HeroSearchService` and still get timely results. Here's how:
 
-* `transform(debounce(... 300)))` waits until the flow of search terms pauses for 300
+* `debounce(... 300))` waits until the flow of search terms pauses for 300
   milliseconds before passing along the latest string.
   You'll never make requests more frequently than 300ms.
 * `distinct()` ensures that a request is sent only if the filter text changed.
-* `transform(switchMap(...))` calls the search service for each
+* `switchMap(...)` calls the search service for each
   search term that makes it through `debounce()` and `distinct()`.
   It cancels and discards previous searches, returning only the
   latest search service stream element.


### PR DESCRIPTION
Update examples to use the `1.0.0` version of `stream_transform` with
extension methods over calling `.transform(something)`. Bump minimum SDK
constraints to `2.6.0` in the pubspecs where the dependency was changed
to allow for using extension methods.